### PR TITLE
Change `land` and `lor` to create flat conjunctions / disjunctions

### DIFF
--- a/src/tarski/syntax/formulas.py
+++ b/src/tarski/syntax/formulas.py
@@ -130,28 +130,17 @@ bot = Contradiction()
 
 
 def land(*args):
-    if len(args) > 2:
-        args = list(args)
-        args.reverse()
-        phi = CompoundFormula(Connective.And, (args[1], args[0]))
-        for k in range(2, len(args)):
-            phi = CompoundFormula(Connective.And, (args[k], phi))
-        return phi
+    """ Create a conjunction of the given formulas """
     return CompoundFormula(Connective.And, args)
 
 
 def lor(*args):
-    if len(args) > 2:
-        args = list(args)
-        args.reverse()
-        phi = CompoundFormula(Connective.Or, (args[1], args[0]))
-        for k in range(2, len(args)):
-            phi = CompoundFormula(Connective.Or, (args[k], phi))
-        return phi
+    """ Create a disjunction of the given formulas """
     return CompoundFormula(Connective.Or, args)
 
 
 def neg(phi):
+    """ Create a negation of the given formula """
     return CompoundFormula(Connective.Not, [phi])
 
 


### PR DESCRIPTION
@miquelramirez , I was trying to get rid of this annoying deep-nesting of conjunctions/disjunctions and opt for flat versions whenever possible. Looks like a simple change to the `lor`, `land` methods could achieve, but unfortunately this breaks two tests related to the CNF and quantifier-free transformations. What do you think? Is it worth changing the tests to support this flat style? Both styles are of course semantically equivalent, not sure if this could break anything on your side that relies on syntactic details.