### PR TITLE
Get rid of unnecessary "accept" method in visitors

### DIFF
--- a/src/tarski/fstrips/contingent/problem.py
+++ b/src/tarski/fstrips/contingent/problem.py
@@ -29,8 +29,8 @@ class ContingentProblem(Problem):
     def get_symbols(self, pv, ev, cv):
         super().get_symbols(pv, ev, cv)
         for _, sensor in self.sensors.items():
-            sensor.condition.accept(pv)
-            sensor.obs.accept(pv)
+            pv.visit(sensor.condition)
+            pv.visit(sensor.obs)
 
     def __str__(self):
         return 'FSTRIPS Contingent Problem "{}", domain "{}"'.format(self.name, self.domain_name)

--- a/src/tarski/fstrips/hybrid/problem.py
+++ b/src/tarski/fstrips/hybrid/problem.py
@@ -48,26 +48,24 @@ class HybridProblem(Problem):
     def get_symbols(self, pv, ev, cv):
         super().get_symbols(pv, ev, cv)
         for _, react in self.reactions.items():
-            react.condition.accept(pv)
+            pv.visit(react.condition)
             eff = react.effect
-            if isinstance(eff, fs.AddEffect):
-                eff.atom.accept(ev)
-            elif isinstance(eff, fs.DelEffect):
-                eff.atom.accept(ev)
+            if isinstance(eff, (fs.AddEffect, fs.DelEffect)):
+                ev.visit(eff.atom)
             elif isinstance(eff, fs.FunctionalEffect):
-                eff.lhs.accept(ev)
+                ev.visit(eff.lhs)
             elif isinstance(eff, fs.ChoiceEffect):
-                eff.lhs.accept(ev)
+                ev.visit(eff.lhs)
             elif isinstance(eff, fs.LogicalEffect):
-                eff.formula.accept(ev)
+                ev.visit(eff.formula)
             elif isinstance(eff, fs.BlackBoxEffect):
                 for yk in eff.lhs[:, 0]:
-                    yk.accept(ev)
+                    ev.visit(yk)
             else:
                 raise RuntimeError("Effect type '{}' cannot be analysed".format(type(eff)))
         for _, dc in self.differential_constraints.items():
-            dc.condition.accept(pv)
-            dc.variate.accept(ev)
+            pv.visit(dc.condition)
+            pv.visit(dc.variate)
 
     def __str__(self):
         return 'FSTRIPS Hybrid Problem "{}", domain "{}"'.format(self.name, self.domain_name)

--- a/src/tarski/fstrips/problem.py
+++ b/src/tarski/fstrips/problem.py
@@ -65,27 +65,25 @@ class Problem:
                 - cv: FluentSymbolCollector tuned for constraints
         """
         for _, act in self.actions.items():
-            act.precondition.accept(pv)
+            pv.visit(act.precondition)
             for eff in act.effects:
-                eff.condition.accept(pv)
-                if isinstance(eff, fs.AddEffect):
-                    eff.atom.accept(ev)
-                elif isinstance(eff, fs.DelEffect):
-                    eff.atom.accept(ev)
+                pv.visit(eff.condition)
+                if isinstance(eff, (fs.AddEffect, fs.DelEffect)):
+                    ev.visit(eff.atom)
                 elif isinstance(eff, fs.FunctionalEffect):
-                    eff.lhs.accept(ev)
+                    ev.visit(eff.lhs)
                 elif isinstance(eff, fs.ChoiceEffect):
-                    eff.obj.accept(ev)
+                    ev.visit(eff.obj)
                     for x in eff.variables:
-                        x.accept(ev)
+                        ev.visit(x)
                 elif isinstance(eff, fs.LogicalEffect):
-                    eff.formula.accept(ev)
+                    ev.visit(eff.formula)
                 else:
                     raise RuntimeError("Effect type '{}' cannot be analysed".format(type(eff)))
 
         for const in self.constraints:
             cv.reset()
-            const.accept(cv)
+            cv.visit(const)
 
     def metric(self, opt_expression, opt_type):
         self.metric_ = fs.OptimizationMetric(opt_expression, opt_type)

--- a/src/tarski/fstrips/visitors.py
+++ b/src/tarski/fstrips/visitors.py
@@ -35,36 +35,34 @@ class FluentSymbolCollector:
     def _visit_action_effect_formula(self, phi):
 
         if isinstance(phi, CompoundFormula):
-            for f in phi.subformulas:
-                f.accept(self)
+            _ = [self.visit(f) for f in phi.subformulas]
+
         elif isinstance(phi, QuantifiedFormula):
-            phi.formula.accept(self)
+            self.visit(phi.formula)
+
         elif isinstance(phi, Atom):
-            # print("Atom: {}".format(str(phi)))
             if not phi.predicate.builtin:
                 self.fluents.add(symref(phi))
             else:
-                for t in phi.subterms:
-                    t.accept(self)
+                _ = [self.visit(f) for f in phi.subterms]
+
         elif isinstance(phi, CompoundTerm):
             # print("Compound Term: {}, {}, {}".format(str(phi), phi.symbol, phi.symbol.builtin))
             if not phi.symbol.builtin:
                 self.fluents.add(symref(phi))
             else:
-                for t in phi.subterms:
-                    t.accept(self)
+                _ = [self.visit(f) for f in phi.subterms]
 
     def _visit_constraint_formula(self, phi):
         if isinstance(phi, ltl.TemporalCompoundFormula) and phi.connective == ltl.TemporalConnective.X:
             old_value = self.under_next
             self.under_next = True
-            for f in phi.subformulas:
-                f.accept(self)
+            _ = [self.visit(f) for f in phi.subformulas]
             self.under_next = old_value
+
         elif isinstance(phi, CompoundFormula):
             old_visited = self.visited.copy()
-            for f in phi.subformulas:
-                f.accept(self)
+            _ = [self.visit(f) for f in phi.subformulas]
             delta = self.visited - old_visited
             # print('Fluents: {}'.format([str(x) for x in self.fluents]))
             # print('Delta: {}'.format([str(x) for x in delta]))
@@ -72,8 +70,10 @@ class FluentSymbolCollector:
                 # print("Fluency propagates")
                 for f in delta:
                     self.fluents.add(f)
+
         elif isinstance(phi, QuantifiedFormula):
-            phi.formula.accept(self)
+            self.visit(phi.formula)
+
         elif isinstance(phi, Atom):
             if not phi.predicate.builtin:
                 self.visited.add(symref(phi))
@@ -82,8 +82,7 @@ class FluentSymbolCollector:
                     self.fluents.add(symref(phi))
             else:
                 self.statics.add(symref(phi))
-            for t in phi.subterms:
-                t.accept(self)
+            _ = [self.visit(f) for f in phi.subterms]
 
         elif isinstance(phi, CompoundTerm):
             if not phi.symbol.builtin:
@@ -93,17 +92,18 @@ class FluentSymbolCollector:
                     self.fluents.add(symref(phi))
             else:
                 self.statics.add(symref(phi))
-            for t in phi.subterms:
-                t.accept(self)
+            _ = [self.visit(f) for f in phi.subterms]
 
     def _visit_precondition_formula(self, phi):
         if isinstance(phi, CompoundFormula):
-            for f in phi.subformulas:
-                f.accept(self)
+            _ = [self.visit(f) for f in phi.subformulas]
+
         elif isinstance(phi, QuantifiedFormula):
-            phi.formula.accept(self)
+            self.visit(phi.formula)
+
         elif isinstance(phi, Atom):
             self.statics.add(symref(phi))
+
         elif isinstance(phi, CompoundTerm):
             self.statics.add(symref(phi))
 

--- a/src/tarski/grounding/naive/constraints.py
+++ b/src/tarski/grounding/naive/constraints.py
@@ -30,7 +30,7 @@ class ConstraintGrounder:
             # 1. Collect set of free variables in the constraint
             const_schema = UniversalQuantifierElimination.rewrite(self.L, const_schema).universal_free
             var_collector = CollectVariables(self.L)
-            const_schema.accept(var_collector)
+            var_collector.visit(const_schema)
             K, syms, substs = instantiation.enumerate_groundings(self.L, list(var_collector.variables))
             for values in itertools.product(*substs):
                 subst = OrderedDict({syms[k]: v for k, v in enumerate(values)})

--- a/src/tarski/grounding/naive/state_variables.py
+++ b/src/tarski/grounding/naive/state_variables.py
@@ -4,12 +4,10 @@
 """
 
 import itertools
-import copy
 
 from ...util import IndexDictionary, DuplicateElementError
 from ... import Variable, Constant
-from ...syntax.transform.subst import TermSubstitution
-
+from ...syntax.transform import term_substitution
 from ..errors import UnableToGroundError
 
 
@@ -45,10 +43,7 @@ class StateVariable:
     @property
     def ground(self):
         subst = {k: v for k, v in zip(self.term.subterms, self.instantiation)}
-        g = copy.deepcopy(self.term)
-        v = TermSubstitution(self.head.language, subst)
-        g.accept(v)
-        return g
+        return term_substitution(self.head.language, self.term, subst)
 
     __repr__ = __str__
 

--- a/src/tarski/syntax/arithmetic/__init__.py
+++ b/src/tarski/syntax/arithmetic/__init__.py
@@ -6,7 +6,7 @@ from ...syntax import Term, AggregateCompoundTerm, CompoundTerm, Constant, Varia
 from ...syntax.algebra import Matrix
 from ... import errors as err
 from ... grounding.naive import instantiation
-from .. transform import TermSubstitution
+from .. transform import term_substitution
 from ..builtins import BuiltinFunctionSymbol, get_arithmetic_binary_functions
 
 
@@ -63,10 +63,7 @@ def summation(*args):
     processed_expr = []
     for values in itertools.product(*substs):
         subst = {syms[k]: v for k, v in enumerate(values)}
-        expr_subst = copy.deepcopy(expr)
-        op = TermSubstitution(L, subst)
-        expr_subst.accept(op)
-        processed_expr.append(expr_subst)
+        processed_expr.append(term_substitution(L, expr, subst))
 
     lhs = processed_expr[0]
     for k in range(1, len(processed_expr)):
@@ -96,10 +93,7 @@ def product(*args):
     processed_expr = []
     for values in itertools.product(*substs):
         subst = {syms[k]: v for k, v in enumerate(values)}
-        expr_subst = copy.deepcopy(expr)
-        op = TermSubstitution(L, subst)
-        expr_subst.accept(op)
-        processed_expr.append(expr_subst)
+        processed_expr.append(term_substitution(L, expr, subst))
 
     lhs = processed_expr[0]
     for k in range(1, len(processed_expr)):

--- a/src/tarski/syntax/formulas.py
+++ b/src/tarski/syntax/formulas.py
@@ -42,12 +42,6 @@ class Formula:
     def __gt__(self, rhs):
         return implies(self, rhs)
 
-    def accept(self, visitor):
-        """
-            Visitor pattern
-        """
-        visitor.visit(self)
-
     def is_syntactically_equal(self, other):
         """ Strict syntactic equivalence, which would tipically be in `__eq__`,
         but here we use `__eq__` for a different purpose """

--- a/src/tarski/syntax/terms.py
+++ b/src/tarski/syntax/terms.py
@@ -104,10 +104,6 @@ class Term:
     def __or__(self, rhs):
         return self.language.dispatch_operator('|', Term, Term, self, rhs)
 
-    def accept(self, visitor):
-        """ Visitor pattern """
-        visitor.visit(self)
-
     def is_syntactically_equal(self, other):
         """ Strict syntactic equivalence, which would tipically be in `__eq__`,
         but here we use `__eq__` for a different purpose """

--- a/src/tarski/syntax/transform/__init__.py
+++ b/src/tarski/syntax/transform/__init__.py
@@ -1,4 +1,5 @@
-from . subst import TermSubstitution
+
+from . subst import TermSubstitution, term_substitution
 from . nnf import NNFTransformation
 from . cnf import CNFTransformation
 from . prenex import PrenexTransformation

--- a/src/tarski/syntax/transform/prenex.py
+++ b/src/tarski/syntax/transform/prenex.py
@@ -5,7 +5,7 @@
 """
 from ..formulas import CompoundFormula, QuantifiedFormula, Connective, Quantifier, lor
 from ..transform.nnf import NNFTransformation
-from ..transform.subst import TermSubstitution
+from ..transform import term_substitution
 
 from .errors import TransformationError
 
@@ -37,8 +37,7 @@ class PrenexTransformation:
                     subst[y] = y2
                     new_variables[(y2.symbol, y2.sort.name)] = y2
         if len(subst) > 0:
-            substitution = TermSubstitution(self.L, subst)
-            rhs.formula.accept(substitution)
+            rhs.formula = term_substitution(self.L, rhs.formula, subst, inplace=True)
         new_phi = QuantifiedFormula(lhs.quantifier, list(new_variables.values()), lor(lhs.formula, rhs.formula))
         return new_phi
 
@@ -59,8 +58,7 @@ class PrenexTransformation:
                 subst[y] = y2
                 new_out_vars.append(y2)
         if len(subst) > 0:
-            substitution = TermSubstitution(self.L, subst)
-            out_phi.accept(substitution)
+            term_substitution(self.L, out_phi, subst, inplace=True)
         phi = CompoundFormula(conn, tuple([lhs, rhs]))
         inner = QuantifiedFormula(inner_q, inner_vars, phi)
         return QuantifiedFormula(out_q, new_out_vars, inner)

--- a/src/tarski/syntax/transform/subst.py
+++ b/src/tarski/syntax/transform/subst.py
@@ -3,8 +3,10 @@
 """
     Substitution Operator
 """
-from ..formulas import CompoundFormula, QuantifiedFormula, Variable, Atom
-from ..terms import CompoundTerm
+import copy
+
+from ..formulas import CompoundFormula, QuantifiedFormula, Variable, Atom, Formula
+from ..terms import CompoundTerm, Term
 from .errors import SubstitutionError
 
 
@@ -22,33 +24,33 @@ class TermSubstitution:
     def visit(self, phi):
 
         if isinstance(phi, CompoundFormula):
-            for f in phi.subformulas:
-                f.accept(self)
+            _ = [self.visit(f) for f in phi.subformulas]
+
         elif isinstance(phi, QuantifiedFormula):
             if any(x in self.subst for x in phi.variables):
                 raise SubstitutionError(phi, self.subst, 'Attempted to substitute variable bound by quantifier')
-            phi.formula.accept(self)
-        elif isinstance(phi, Atom):
+            self.visit(phi.formula)
+
+        elif isinstance(phi, (Atom, CompoundTerm)):
             new_subterms = list(phi.subterms)
             for k, t in enumerate(new_subterms):
                 rep = self.subst.get(t, None)
                 if rep is None:
-                    t.accept(self)
+                    self.visit(t)
                 else:
                     if isinstance(rep, Variable):
                         new_subterms[k] = rep
                     else:
                         new_subterms[k] = rep
             phi.subterms = tuple(new_subterms)
-        elif isinstance(phi, CompoundTerm):
-            new_subterms = list(phi.subterms)
-            for k, t in enumerate(new_subterms):
-                rep = self.subst.get(t, None)
-                if rep is None:
-                    t.accept(self)
-                else:
-                    if isinstance(rep, Variable):
-                        new_subterms[k] = rep
-                    else:
-                        new_subterms[k] = rep
-            phi.subterms = tuple(new_subterms)
+
+
+def term_substitution(language, phi, substitution, inplace=False):
+    """ Return the result of applying the given substitution to the given formula or term of the language.
+    If `inplace` is true, the given formula is the one modified.
+    """
+    assert isinstance(phi, (Formula, Term))
+    phi = phi if inplace else copy.deepcopy(phi)
+    op = TermSubstitution(language, substitution)
+    op.visit(phi)
+    return phi

--- a/src/tarski/syntax/transform/univ_elim.py
+++ b/src/tarski/syntax/transform/univ_elim.py
@@ -3,11 +3,8 @@
     Universal Quantification Elimination
 """
 import itertools
-import copy
 from ..formulas import land, Quantifier, QuantifiedFormula
-from ..transform.prenex import PrenexTransformation
-from ..transform.subst import TermSubstitution
-
+from ..transform import term_substitution, PrenexTransformation
 from .errors import TransformationError
 
 
@@ -34,10 +31,7 @@ class UniversalQuantifierElimination:
                 conjuncts = []
                 for values in itertools.product(*substs):
                     subst = {syms[k]: v for k, v in enumerate(values)}
-                    g_const = copy.deepcopy(phi.formula)
-                    op = TermSubstitution(self.L, subst)
-                    g_const.accept(op)
-                    conjuncts.append(g_const)
+                    conjuncts.append(term_substitution(self.L, phi.formula, subst))
                 # print(len(conjuncts))
                 return land(*conjuncts)
 

--- a/tests/fol/test_syntactic_analysis.py
+++ b/tests/fol/test_syntactic_analysis.py
@@ -23,5 +23,5 @@ def test_detect_free_variables():
     y = tw.variable('y', tw.Object)
     s = neg(land(tw.Cube(x), exists(y, land(tw.Tet(x), tw.LeftOf(x, y)))))
     v = CollectFreeVariables(tw)
-    s.accept(v)
+    v.visit(s)
     assert len(list(v.free_variables)) == 1


### PR DESCRIPTION
In spite of affecting a good number of files, this PR does a simple change: it gets rid of the `accept()` methods in the term/formula FSTRIPS hierarchy, which were doing a redundant job: simply calling the visitor `visit()` method. That is standard in C++ visitor implementations, but it is not necessary in Python, since the visitor is doing all of the job by calling `isinstance` anyway. This should not break anything, and tests are passing OK.

I also implemented, as a proof of concept, a `term_substitution` "wrapper" that offers a cleaner interface to the calling methods that want to compute a term substitution. We could do the same with other transformations, but I didn't want to complicate this PR further.