### PR TITLE
Possible solution to #71

### DIFF
--- a/docs/notebooks/001_first_order_logics.ipynb
+++ b/docs/notebooks/001_first_order_logics.ipynb
@@ -46,7 +46,7 @@
    },
    "outputs": [],
    "source": [
-    "fol = tarski.language()"
+    "fol = tarski.language(theories=['equality', 'arithmetic'])"
    ]
   },
   {
@@ -1337,10 +1337,10 @@
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
+    "source": [],
     "metadata": {
      "collapsed": false
-    },
-    "source": []
+    }
    }
   }
  },

--- a/docs/notebooks/002_fol_semantics.ipynb
+++ b/docs/notebooks/002_fol_semantics.ipynb
@@ -14,23 +14,14 @@
    "outputs": [],
    "source": [
     "import tarski\n",
-    "from tarski.theories import Theory"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "\n",
     "# 1. Create language used to describe world states and transitions\n",
-    "bw = tarski.language(theories=[Theory.EQUALITY])"
+    "bw = tarski.language(theories=['equality', 'arithmetic'])\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
    "outputs": [],
    "source": [
     "# 2. Define sorts\n",
@@ -43,7 +34,13 @@
     "\n",
     "# 4. Define predicates\n",
     "clear = bw.predicate( 'clear', block)\n"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",
@@ -525,10 +522,10 @@
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
+    "source": [],
     "metadata": {
      "collapsed": false
-    },
-    "source": []
+    }
    }
   }
  },

--- a/docs/notebooks/003_planning_problems.ipynb
+++ b/docs/notebooks/003_planning_problems.ipynb
@@ -39,17 +39,9 @@
    "source": [
     "import tarski\n",
     "from tarski.syntax import *\n",
-    "from tarski.theories import Theory"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "\n",
     "# 1. Create language to model the domain\n",
-    "bw = tarski.language('BlocksWorld', theories=[Theory.EQUALITY])"
+    "bw = tarski.language('BlocksWorld', theories=['equality', 'arithmetic'])"
    ]
   },
   {
@@ -599,10 +591,10 @@
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
+    "source": [],
     "metadata": {
      "collapsed": false
-    },
-    "source": []
+    }
    }
   }
  },

--- a/docs/notebooks/004_advanced_techniques.ipynb
+++ b/docs/notebooks/004_advanced_techniques.ipynb
@@ -18,7 +18,7 @@
     "import tarski\n",
     "\n",
     "# 1. Create language equipped with the Arithmetic theory\n",
-    "bw = tarski.language(theories=[tarski.Theories.ARITHMETIC])\n",
+    "bw = tarski.language(theories=['equality', 'arithmetic'])\n",
     "\n",
     "# 2. Define sorts\n",
     "place = bw.sort('place')\n",

--- a/src/tarski/fol.py
+++ b/src/tarski/fol.py
@@ -5,13 +5,8 @@ from collections import defaultdict, OrderedDict
 from typing import Union
 
 from . import errors as err
-from .syntax import Function, Constant, Variable, Sort, inclusion_closure, Predicate, Interval, sorts
+from .syntax import Function, Constant, Variable, Sort, inclusion_closure, Predicate, Interval
 from .syntax.algebra import Matrix
-
-
-def language(name='Tarski FOL'):
-    """ A helper to construct languages"""
-    return FirstOrderLanguage(name)
 
 
 class FirstOrderLanguage:
@@ -40,7 +35,7 @@ class FirstOrderLanguage:
         self.language_components_frozen = False
         self.theories = []
 
-        self._build_builtin_sorts()
+        self._attach_object_sort()
 
     def __deepcopy__(self, memo):
         """ At the moment we forbid deep copies of this class, as they might be too expensive"""
@@ -68,55 +63,33 @@ class FirstOrderLanguage:
     def functions(self):
         return self._functions.values()
 
-    @property
-    def Object(self):
-        return self._sorts['object']
-
-    @property
-    def Real(self):
-        return self._sorts['Real']
-
-    @property
-    def Integer(self):
-        return self._sorts['Integer']
-
-    @property
-    def Natural(self):
-        return self._sorts['Natural']
-
-    def _build_builtin_sorts(self):
-        self._build_the_objects()
-        self._build_the_reals()
-        self._build_the_integers()
-        self._build_the_naturals()
-
-    def _build_the_reals(self):
-        the_reals = sorts.build_the_reals(self)
-        self._sorts['Real'] = the_reals
-        self.set_parent(the_reals, self.Object)
-        # self.create_builtin_predicates(the_reals)
-        self._global_index['Real'] = the_reals
-
-    def _build_the_integers(self):
-        the_ints = sorts.build_the_integers(self)
-        self._sorts['Integer'] = the_ints
-        self.set_parent(the_ints, self.Real)
-        # self.create_builtin_predicates(the_ints)
-        self._global_index['Integer'] = the_ints
-
-    def _build_the_naturals(self):
-        the_nats = sorts.build_the_naturals(self)
-        self._sorts['Natural'] = the_nats
-        self.set_parent(the_nats, self.Integer)
-        # self.create_builtin_predicates(the_nats)
-        self._global_index['Natural'] = the_nats
-
-    def _build_the_objects(self):
+    def _attach_object_sort(self):
+        """ The `object` sort, being the root of the sort hierarchy, needs a special treatment"""
         sort = Sort('object', self)
         self._sorts['object'] = sort
         self._global_index['object'] = sort
         self.immediate_parent[sort] = None
         self.ancestor_sorts[sort] = set()
+
+    @property
+    def Object(self):
+        """ A shorthand accessor. """
+        return self._sorts['object']
+
+    @property
+    def Real(self):
+        """ A shorthand accessor. """
+        return self.get_sort('Real')
+
+    @property
+    def Integer(self):
+        """ A shorthand accessor. """
+        return self.get_sort('Integer')
+
+    @property
+    def Natural(self):
+        """ A shorthand accessor. """
+        return self.get_sort('Natural')
 
     def sort(self, name: str, parent: Union[Sort, str, None] = None):
         """
@@ -127,16 +100,20 @@ class FirstOrderLanguage:
             Raises err.DuplicateSortDefinition if a sort with the same name already existed,
              or err.DuplicateDefinition if some non-sort element with the same name already existed.
         """
-        self._check_name_not_defined(name, self._sorts, err.DuplicateSortDefinition)
-
-        sort = Sort(name, self)
-        self._sorts[name] = sort
-        self._global_index[name] = sort
-
         parent = self.get_sort("object") if parent is None else self._retrieve_sort(parent)
+        return self.attach_sort(Sort(name, self), parent)
+
+    def attach_sort(self, sort: Sort, parent: Sort):
+        """ Attach a given sort to the language. For standard creation of sorts, better use `lang.sort()`. """
+        self._check_name_not_defined(sort.name, self._sorts, err.DuplicateSortDefinition)
+
+        # Register the sort itself
+        self._sorts[sort.name] = sort
+        self._global_index[sort.name] = sort
+
+        # Register the sort parent
         self.set_parent(sort, parent)
 
-        # self.create_builtin_predicates(sort)
         return sort
 
     def has_sort(self, name: str):
@@ -183,7 +160,7 @@ class FirstOrderLanguage:
 
         p = self.immediate_parent.get(sort, None)
         if p is not None:
-            raise err.LanguageError('Tried to set parent of sort "{}", which has already parent {}'.format(sort, p))
+            raise err.LanguageError(f'Tried to set parent of sort "{sort}", which has already parent {p}')
 
         self.immediate_parent[sort] = parent
         self.ancestor_sorts[sort].update(inclusion_closure(parent))

--- a/src/tarski/fstrips/fstrips.py
+++ b/src/tarski/fstrips/fstrips.py
@@ -1,6 +1,6 @@
 
 from enum import Enum
-from typing import List, Callable, Any
+from typing import Union, List, Optional, Callable, Any
 
 from ..syntax import CompoundTerm, Term, Constant, symref, top
 from .. import theories as ths
@@ -287,13 +287,12 @@ class OptimizationMetric:
         self.opt_type = opt_type
 
 
-def language(name="Unnamed FOL Language", theories=None):
+def language(name="Unnamed FOL Language", theories: Optional[List[Union[str, ths.Theory]]] = None):
     """ Create an FSTRIPS-oriented First-Order Language.
         This is a standard FOL with a few convenient add-ons.
     """
     # By default, when defining a FSTRIPS problem we use FOL with equality
-    if theories is None:
-        theories = [ths.Theory.EQUALITY]
+    theories = ['equality'] if theories is None else theories
     lang = ths.language(name, theories)
     lang.register_operator_handler("<<", Term, Term, FunctionalEffect)
     lang.register_operator_handler(">>", Term, Term, lambda lhs, rhs: FunctionalEffect(rhs, lhs))  # Inverted

--- a/src/tarski/syntax/sorts.py
+++ b/src/tarski/syntax/sorts.py
@@ -190,3 +190,9 @@ def build_the_reals(lang):
     reals.builtin = True
     # the_reals.pi = scipy.constants.pi
     return reals
+
+
+def attach_arithmetic_sorts(lang):
+    real_t = lang.attach_sort(build_the_reals(lang), lang.ns.object)
+    int_t = lang.attach_sort(build_the_integers(lang), real_t)
+    _ = lang.attach_sort(build_the_naturals(lang), int_t)

--- a/src/tarski/theories.py
+++ b/src/tarski/theories.py
@@ -24,11 +24,6 @@ def language(name='L', theories=None):
     """ Build a language with the given name and configure it with the given theories """
     theories = theories or []
     lang = FirstOrderLanguage(name)
-    theories_requiring_arithmetic_sorts = {
-        Theory.ARITHMETIC, Theory.SPECIAL, Theory.RANDOM
-    }
-    if any(t in theories_requiring_arithmetic_sorts for t in theories):
-        attach_arithmetic_sorts(lang)
     _ = [load_theory(lang, t) for t in theories]
     return lang
 
@@ -46,6 +41,12 @@ def load_theory(lang, theory):
     loader = loaders.get(theory)
     if loader is None:
         raise err.UnknownTheory(theory)
+
+    theories_requiring_arithmetic_sorts = {
+        Theory.ARITHMETIC, Theory.SPECIAL, Theory.RANDOM
+    }
+    if theory in theories_requiring_arithmetic_sorts and not lang.has_sort('Integer'):
+        attach_arithmetic_sorts(lang)
 
     loader(lang)
     lang.theories.append(theory)

--- a/src/tarski/theories.py
+++ b/src/tarski/theories.py
@@ -1,6 +1,7 @@
 """ Management of the theories (e.g. equality, etc.) associated to the FO languages """
 from enum import Enum
 
+from tarski.syntax.sorts import attach_arithmetic_sorts
 from .fol import FirstOrderLanguage
 from .syntax import builtins, Term
 from .syntax.factory import create_atom, create_arithmetic_term
@@ -23,6 +24,11 @@ def language(name='L', theories=None):
     """ Build a language with the given name and configure it with the given theories """
     theories = theories or []
     lang = FirstOrderLanguage(name)
+    theories_requiring_arithmetic_sorts = {
+        Theory.ARITHMETIC, Theory.SPECIAL, Theory.RANDOM
+    }
+    if any(t in theories_requiring_arithmetic_sorts for t in theories):
+        attach_arithmetic_sorts(lang)
     _ = [load_theory(lang, t) for t in theories]
     return lang
 

--- a/tests/common/parcprinter.py
+++ b/tests/common/parcprinter.py
@@ -10,7 +10,7 @@ from tarski.evaluators.simple import evaluate
 
 
 def create_small_language():
-    upp = tsk.fstrips.language("upp", theories=[Theory.EQUALITY])
+    upp = tsk.fstrips.language("upp", theories=[Theory.EQUALITY, Theory.ARITHMETIC])
 
     upp.sheet_t = upp.sort('sheet_t')
     upp.resource_t = upp.sort('resource_t')

--- a/tests/fol/test_interpretations.py
+++ b/tests/fol/test_interpretations.py
@@ -338,7 +338,7 @@ def test_predicate_extensions():
 
 
 def test_predicate_without_equality():
-    lang = tarski.language(theories=[])
+    lang = tarski.language(theories=[Theory.ARITHMETIC])
     leq = lang.predicate('leq', lang.Integer, lang.Integer)
     f = lang.function('f', lang.Object, lang.Integer)
     o1 = lang.constant("o1", lang.Object)
@@ -411,7 +411,7 @@ def test_model_as_atoms():
 def test_predicate_without_equality_reals():
     import numpy
 
-    lang = tarski.language(theories=[])
+    lang = tarski.language(theories=[Theory.ARITHMETIC])
     leq = lang.predicate('leq', lang.Real, lang.Real)
     w = lang.function('w', lang.Object, lang.Real)
     o1 = lang.constant("o1", lang.Object)

--- a/tests/fol/test_syntax.py
+++ b/tests/fol/test_syntax.py
@@ -15,6 +15,10 @@ from ..common import numeric
 
 
 def test_language_creation():
+    lang = theories.language()
+    sorts = sorted(x.name for x in lang.sorts)
+    assert sorts == ['object']
+
     lang = fstrips.language("test", theories=[])
     sorts = sorted(x.name for x in lang.sorts)
     assert sorts == ['object']

--- a/tests/fol/test_syntax.py
+++ b/tests/fol/test_syntax.py
@@ -29,19 +29,10 @@ def test_language_creation():
 
 
 def test_builtin_constants():
-    lang = fstrips.language()
+    lang = fstrips.language(theories=[Theory.ARITHMETIC])
     ints = lang.Integer
     two = lang.constant(2, ints)
     assert isinstance(two, Constant), "two should be the constant 2, not the integer value 2"
-
-
-def test_arithmetic_terms_fails_without_import():
-    lang = fstrips.language()
-    ints = lang.Integer
-    two, three = lang.constant(2, ints), lang.constant(3, ints)
-    with pytest.raises(err.LanguageError):
-        # This should raise TypeError as the arithmetic module has not been loaded
-        _ = two + three
 
 
 def test_arithmetic_term_plus_float_lit_is_term():
@@ -64,7 +55,7 @@ def test_arithmetic_terms_does_not_fail_with_load_theory():
 
 
 def test_load_arithmetic_module_fails_when_language_frozen():
-    lang = fstrips.language()
+    lang = fstrips.language(theories=[Theory.ARITHMETIC])
     ints = lang.Integer
     two, three = lang.constant(2, ints), lang.constant(3, ints)
 
@@ -182,7 +173,7 @@ def test_duplicate_detection_and_global_getter():
 
 
 def test_term_refs():
-    lang = fstrips.language()
+    lang = fstrips.language(theories=[Theory.ARITHMETIC])
     _ = lang.function('f', lang.Object, lang.Integer)
     o1 = lang.constant("o1", lang.Object)
     o2 = lang.constant("o2", lang.Object)
@@ -214,7 +205,7 @@ def test_object_function_arity():
 
 
 def test_term_refs_compound():
-    lang = fstrips.language()
+    lang = fstrips.language(theories=[Theory.ARITHMETIC])
     f = lang.function('f', lang.Object, lang.Integer)
     o1 = lang.constant("o1", lang.Object)
     o2 = lang.constant("o2", lang.Object)

--- a/tests/fol/test_syntax.py
+++ b/tests/fol/test_syntax.py
@@ -14,6 +14,16 @@ from tarski.syntax.algebra import Matrix
 from ..common import numeric
 
 
+def test_language_creation():
+    lang = fstrips.language("test", theories=[])
+    sorts = sorted(x.name for x in lang.sorts)
+    assert sorts == ['object']
+
+    lang = fstrips.language("test")
+    sorts = sorted(x.name for x in lang.sorts)
+    assert sorts == ['object']  # The default equality theory should not import the arithmetic sorts either
+
+
 def test_builtin_constants():
     lang = fstrips.language()
     ints = lang.Integer

--- a/tests/fol/test_types.py
+++ b/tests/fol/test_types.py
@@ -15,6 +15,7 @@ from tarski.syntax.sorts import parent, ancestors
 #
 #     lang.constant('Miquel', s)
 #     lang.check_well_formed()
+from tarski.theories import Theory
 
 
 def test_object_type():
@@ -79,7 +80,7 @@ def get_children_parent_types():
 
 
 def test_ints():
-    lang = tsk.fstrips.language()
+    lang = tsk.fstrips.language(theories=[Theory.ARITHMETIC])
     ints = lang.Integer
     assert ints.contains(1)
     assert ints.contains(0)
@@ -89,7 +90,7 @@ def test_ints():
 
 
 def test_naturals():
-    lang = tsk.fstrips.language()
+    lang = tsk.fstrips.language(theories=[Theory.ARITHMETIC])
     nats = lang.Natural
     assert nats.contains(999)
     assert not nats.contains(-12)
@@ -97,20 +98,20 @@ def test_naturals():
 
 
 def test_reals():
-    lang = tsk.fstrips.language()
+    lang = tsk.fstrips.language(theories=[Theory.ARITHMETIC])
     reals = lang.Real
     assert reals.contains(1000.36)
     assert reals.contains(-17)
 
 
 def test_integer_subtypes():
-    lang = tsk.fstrips.language()
+    lang = tsk.fstrips.language(theories=[Theory.ARITHMETIC])
     nats = lang.Natural
     _ = lang.sort("counter", nats)
 
 
 def test_interval_types_valid():
-    lang = tsk.fstrips.language()
+    lang = tsk.fstrips.language(theories=[Theory.ARITHMETIC])
     int_t = lang.Integer
     interval_sort = lang.interval('I', int_t, 0, 10)
     assert interval_sort.lower_bound == 0
@@ -119,14 +120,14 @@ def test_interval_types_valid():
 
 
 def test_interval_types_invalid():
-    lang = tsk.fstrips.language()
+    lang = tsk.fstrips.language(theories=[Theory.ARITHMETIC])
     int_t = lang.Integer
     with pytest.raises(err.SemanticError):
         _ = lang.interval('I', int_t, 10, 0)
 
 
 def test_interval_types_create_valid_constant():
-    lang = tsk.fstrips.language()
+    lang = tsk.fstrips.language(theories=[Theory.ARITHMETIC])
     int_t = lang.Integer
     interval_sort = lang.interval('I', int_t, 0, 10)
     ii = tsk.syntax.Constant(3, interval_sort)
@@ -134,7 +135,7 @@ def test_interval_types_create_valid_constant():
 
 
 def test_interval_types_create_invalid_constant():
-    lang = tsk.fstrips.language()
+    lang = tsk.fstrips.language(theories=[Theory.ARITHMETIC])
     int_t = lang.Integer
     interval_sort = lang.interval('I', int_t, 0, 10)
     with pytest.raises(ValueError):
@@ -142,7 +143,7 @@ def test_interval_types_create_invalid_constant():
 
 
 def test_interval_types_create_invalid_constant2():
-    lang = tsk.fstrips.language()
+    lang = tsk.fstrips.language(theories=[Theory.ARITHMETIC])
     int_t = lang.Integer
     interval_sort = lang.interval('I', int_t, 0, 10)
     with pytest.raises(ValueError):

--- a/tests/fstrips/test_actions.py
+++ b/tests/fstrips/test_actions.py
@@ -2,6 +2,7 @@ import pytest
 
 from tarski import fstrips as fs
 from tarski.syntax import *
+from tarski.theories import Theory
 
 from ..common import blocksworld
 
@@ -41,7 +42,7 @@ def test_functional_effect_valid_creation():
 
 
 def test_increase_effect_valid_creation():
-    lang = fs.language('lang')
+    lang = fs.language('lang', theories=[Theory.EQUALITY, Theory.ARITHMETIC])
     lang.total_cost = lang.function('total-cost', lang.Real)
     eff = fs.IncreaseEffect(lang.total_cost(), 5)
 

--- a/tests/io/test_fstrips_writer.py
+++ b/tests/io/test_fstrips_writer.py
@@ -8,6 +8,7 @@ from tarski.io import FstripsWriter
 from tarski.io._fstrips.common import get_requirements_string
 from tarski.io.fstrips import print_effects, print_effect, print_objects, print_metric, print_formula, print_term
 from tarski.syntax import forall, exists, Constant
+from tarski.theories import Theory
 
 from tests.common.blocksworld import generate_small_fstrips_bw_problem
 from tests.common import parcprinter
@@ -92,7 +93,7 @@ def test_objects_writing():
 
 
 def test_metric_writing():
-    lang = fs.language('lang')
+    lang = fs.language('lang', theories=[Theory.ARITHMETIC])
     cost = lang.function('total-cost', lang.Real)
     metric = fs.OptimizationMetric(cost(), fs.OptimizationType.MINIMIZE)
     metric_string = print_metric(metric)
@@ -136,10 +137,7 @@ def test_requirements_string():
     problem = parcprinter.create_small_task()
 
     # action costs should be required if there is a metric defined.
-    reqs = get_requirements_string(problem)
-    assert ':numeric-fluents' not in reqs
-    assert ':action-costs' in reqs
-    assert ':equality' in reqs
+    assert sorted(get_requirements_string(problem)) == [':action-costs', ':equality', ':numeric-fluents', ':typing']
 
     problem, loc, clear, b1, table = get_bw_elements()
     assert sorted(get_requirements_string(problem)) == [':equality', ':typing']


### PR DESCRIPTION
@miquelramirez , what do you think about this? The documentation would still need to be fixed, but I can do that later, this PR is just to discuss the possible implementation. Perhaps it'd be good to offer easier ways to declare the desired theories upon creation of a language (e.g. `language('name', theories='ae')` instead of the more verbose `language('name', theories=[Theory.EQUALITY, Theory.ARITHMETIC])`, but that's just syntactic sugar. Or we could also offer shorthands `language_with_eq()`, `arithmetic_language()`, etc. But overall I'd like to be able to have a language *without* arithmetic types.