### PR TITLE
Adds logic to use the correct stdout id on MacOS when environment is "darwin"

### DIFF
--- a/src/tarski/utils/command.py
+++ b/src/tarski/utils/command.py
@@ -70,7 +70,11 @@ def silentremove(filename):
 
 
 libc = ctypes.CDLL(None)
-c_stdout = ctypes.c_void_p.in_dll(libc, 'stdout')
+if sys.platform == "darwin":
+    stdout_name = '__stdoutp'
+else:
+    stdout_name = 'stdout'
+c_stdout = ctypes.c_void_p.in_dll(libc, stdout_name)
 
 
 @contextmanager


### PR DESCRIPTION
I'm not sure how interested you all are in supporting `tarski` on macos. I know that a few people working with it now do development work with it locally on macs, although I believe it's generally deployed in linux environments.

Previously, tests (as well as actual use) would fail on macos due to a mismatch between the expected cytpe ID for `stdout` (`stdout` -- as it typically is on linux) and the actual ctype ID (`__stdoutp`). This fix just directly assigns the string to be `__stdoutp` in the case when we are in a `darwin` environment.

As far as I can tell, this is the best way to do this that's straightforward, since it appears that `stdout` is generally a macro, rather than a variable. It appears macos is the weird one out here, so it seems to make sense to just fix the problem directly. 