### PR TITLE
Added string model parsing in clingo wrapper

### DIFF
--- a/src/tarski/errors.py
+++ b/src/tarski/errors.py
@@ -155,6 +155,9 @@ class OutOfMemoryError(TarskiError):
 class OutOfTimeError(TarskiError):
     pass
 
+class ArgumentError(TarskiError):
+    pass
+
 
 # class WrongTermUsageError(TarskiError):
 #     def __init__(self):

--- a/src/tarski/grounding/lp_grounding.py
+++ b/src/tarski/grounding/lp_grounding.py
@@ -66,7 +66,7 @@ class LPGroundingStrategy:
         if self.model is None:
             lp, tr = create_reachability_lp(self.problem, self.do_ground_actions, self.include_variable_inequalities)
             model_filename, theory_filename = run_clingo(lp)
-            self.model = parse_model(model_filename, tr)
+            self.model = parse_model(filename=model_filename, symbol_mapping=tr)
 
             # Remove the input and output files for Gringo
             silentremove(model_filename)

--- a/src/tarski/reachability/clingo_wrapper.py
+++ b/src/tarski/reachability/clingo_wrapper.py
@@ -59,3 +59,21 @@ def parse_model(filename, symbol_mapping):
                 raise RuntimeError('Unexpected line "{}" in Clingo solution file'.format(line))
 
     return model
+
+def parse_model_string(string, symbol_mapping):
+    tr = symbol_mapping
+    model = defaultdict(set)
+    for line in string.split('\n'):
+        data = line.rstrip(' \n.').rstrip(')')
+        components = data.split('(')
+        if len(components) == 1:
+            symbol = tr.back(components[0])
+            model[symbol].add(())
+        elif len(components) == 2:
+            symbol, arguments = components
+            model[tr.back(symbol)].add(tuple(tr.back(s) for s in arguments.split(',')))
+        else:
+            # No nested terms expected, so there should be at most 2 components
+            raise RuntimeError('Unexpected line "{}" in Clingo solution file'.format(line))
+        
+    return model

--- a/src/tarski/reachability/clingo_wrapper.py
+++ b/src/tarski/reachability/clingo_wrapper.py
@@ -43,9 +43,9 @@ def run_clingo(lp):
 def parse_model(*, filename=None, content=None, symbol_mapping):
     if filename and not content:
         with open(filename, "r") as f:
-            return _parse_model((l for l in f), symbol_mapping)
+            return _parse_model(f, symbol_mapping)
     elif content and not filename:
-        return _parse_model((l for l in content.splitlines()), symbol_mapping)
+        return _parse_model(content.splitlines(), symbol_mapping)
     else:
         raise ArgumentError(f"Cannot have both filename and content as arguments.")
 

--- a/src/tarski/reachability/clingo_wrapper.py
+++ b/src/tarski/reachability/clingo_wrapper.py
@@ -42,14 +42,11 @@ def run_clingo(lp):
 
 def parse_model(*, filename=None, content=None, symbol_mapping):
     if filename and not content:
-        with open(filename, "r") as f:
-            lines = f.readlines()
+        return _parse_model((l for l in filename), symbol_mapping)
     elif content and not filename:
-        lines = content.splitlines()
+        return _parse_model((l for l in content.splitlines()), symbol_mapping)
     else:
         raise ArgumentError(f"Cannot have both filename and content as arguments.")
-    
-    return _parse_model(lines, symbol_mapping)
 
 def _parse_model(lines, symbol_mapping):
     tr = symbol_mapping

--- a/src/tarski/reachability/clingo_wrapper.py
+++ b/src/tarski/reachability/clingo_wrapper.py
@@ -42,7 +42,8 @@ def run_clingo(lp):
 
 def parse_model(*, filename=None, content=None, symbol_mapping):
     if filename and not content:
-        return _parse_model((l for l in filename), symbol_mapping)
+        with open(filename, "r") as f:
+            return _parse_model((l for l in f), symbol_mapping)
     elif content and not filename:
         return _parse_model((l for l in content.splitlines()), symbol_mapping)
     else:


### PR DESCRIPTION
A sort of addition onto my last commit - same theme. Needed to be able to create a model based on a string instead of a temp file. If there should be a better naming convention, feel free to change it up.

Again, if this functionality exists elsewhere, let me know!