### PR TITLE
Support and testing for equality-atom and if-then-else based RDDL-style boolean interoperability

### DIFF
--- a/src/tarski/syntax/arithmetic/random.py
+++ b/src/tarski/syntax/arithmetic/random.py
@@ -14,6 +14,14 @@ def normal(mu, sigma):
             return np.random.normal(mu, sigma)
     return normal_func(mu, sigma)
 
+def bernoulli(p):
+    try:
+        bernoulli_func = p.language.get_function(bfs.BERNOULLI)
+    except AttributeError:
+        np = modules.import_numpy()
+        return np.random.random(p)
+    return bernoulli_func(p)
+
 
 def gamma(shape, scale):
     try:

--- a/src/tarski/syntax/builtins.py
+++ b/src/tarski/syntax/builtins.py
@@ -111,9 +111,8 @@ def get_random_binary_functions():
 
 
 def get_random_unary_functions():
-    # BFS = BuiltinFunctionSymbol
-    return []
-
+    BFS = BuiltinFunctionSymbol
+    return [BFS.BERNOULLI]
 
 def get_predicate_from_symbol(symbol: str):
     return BuiltinPredicateSymbol(symbol)

--- a/src/tarski/syntax/terms.py
+++ b/src/tarski/syntax/terms.py
@@ -110,7 +110,7 @@ class Term:
 
     def __and__(self, rhs):
         return self.language.dispatch_operator('&', Term, Term, self, rhs)
-
+    
     def __xor__(self, rhs):
         return self.language.dispatch_operator('^', Term, Term, self, rhs)
 

--- a/src/tarski/theories.py
+++ b/src/tarski/theories.py
@@ -57,7 +57,7 @@ def load_theory(lang, theory: Union[Theory, str]):
         raise err.UnknownTheory(theory)
 
     theories_requiring_arithmetic_sorts = {
-        Theory.ARITHMETIC, Theory.SPECIAL, Theory.RANDOM
+        Theory.ARITHMETIC, Theory.SPECIAL, Theory.RANDOM, Theory.BOOLEAN
     }
     if th in theories_requiring_arithmetic_sorts and not lang.has_sort('Integer'):
         attach_arithmetic_sorts(lang)
@@ -129,7 +129,7 @@ def load_random_theory(lang):
         f.builtin = True
     for fun in builtins.get_random_unary_functions():
         lang.register_unary_operator_handler(fun, Term, create_casting_handler(lang, fun, create_arithmetic_term))
-        f = lang.function(fun, lang.Real, lang.Real)
+        f = lang.function(fun, lang.Real, lang.Boolean)
         f.builtin = True
 
 

--- a/tests/fol/test_sorts.py
+++ b/tests/fol/test_sorts.py
@@ -201,3 +201,25 @@ def test_sort_domain_retrieval():
 
     with pytest.raises(err.TarskiError):
         lang.Integer.domain()  # Domain too large to iterate over it
+
+def test_boolean_sort_no_arithmetic_theory():
+    #todo: [Pete] should force Equality theory when Boolean attached?
+    lang = tarski.language(theories=[Theory.BOOLEAN, Theory.EQUALITY])
+    assert lang.Boolean in lang.sorts, 'the Boolean sort should be attached'
+    assert lang.Object in lang.sorts, 'the object sort should be the only other sort'
+    assert len(lang.sorts) == 2, 'the Boolean and Object sorts should be the only sorts'
+
+    assert isinstance(lang.Boolean, Interval), 'the Boolean sort is an interval'
+    assert lang.Boolean.cardinality() == 2, 'Boolean sort is of cardinality 2'
+    assert lang.Boolean.builtin == True
+    assert parent(lang.Boolean) == lang.Object, 'since there are no numeric sorts, the Boolean sort has parent Object'
+
+def test_boolean_sort_with_arithmetic_theory():
+    lang = tarski.language(theories=[Theory.BOOLEAN, Theory.EQUALITY, Theory.ARITHMETIC])
+    assert lang.Boolean in lang.sorts, 'the Boolean sort should always be attached'
+    assert len(lang.sorts) == 5, 'sorts Boolean, Integer, Naturals, Reals and Object attached'
+
+    assert isinstance(lang.Boolean, Interval), 'the Boolean sort is an interval'
+    assert lang.Boolean.cardinality() == 2, 'Boolean sort is of cardinality 2'
+    assert lang.Boolean.builtin == True
+    assert parent(lang.Boolean) == lang.Natural, 'when there are numeric sorts, the parent of Boolean is Naturals'

--- a/tests/fol/test_sorts.py
+++ b/tests/fol/test_sorts.py
@@ -6,7 +6,7 @@ import tarski.errors as err
 from tarski.benchmarks.counters import generate_fstrips_counters_problem
 from tarski.syntax import symref
 from tarski.syntax.ops import compute_sort_id_assignment
-from tarski.syntax.sorts import parent, ancestors, compute_signature_bindings, compute_direct_sort_map
+from tarski.syntax.sorts import parent, ancestors, compute_signature_bindings, compute_direct_sort_map, Interval
 from tarski.theories import Theory
 
 
@@ -207,12 +207,15 @@ def test_boolean_sort_no_arithmetic_theory():
     lang = tarski.language(theories=[Theory.BOOLEAN, Theory.EQUALITY])
     assert lang.Boolean in lang.sorts, 'the Boolean sort should be attached'
     assert lang.Object in lang.sorts, 'the object sort should be the only other sort'
-    assert len(lang.sorts) == 2, 'the Boolean and Object sorts should be the only sorts'
+    assert lang.Integer in lang.sorts
+    assert lang.Real in lang.sorts
+    assert lang.Natural in lang.sorts
+    assert len(lang.sorts) == 5, 'the Boolean and Object sorts should be attached, in addition to numeric sorts (implicitly)'
 
     assert isinstance(lang.Boolean, Interval), 'the Boolean sort is an interval'
     assert lang.Boolean.cardinality() == 2, 'Boolean sort is of cardinality 2'
     assert lang.Boolean.builtin == True
-    assert parent(lang.Boolean) == lang.Object, 'since there are no numeric sorts, the Boolean sort has parent Object'
+    assert parent(lang.Boolean) == lang.Natural, 'Boolean sort always has the naturals as parent'
 
 def test_boolean_sort_with_arithmetic_theory():
     lang = tarski.language(theories=[Theory.BOOLEAN, Theory.EQUALITY, Theory.ARITHMETIC])

--- a/tests/io/test_rddl_writer.py
+++ b/tests/io/test_rddl_writer.py
@@ -476,7 +476,7 @@ def test_parametrized_model_with_random_vars_and_waypoints_boolean():
 
 def test_rddl_integration_with_boolean_patterns_academic_advising_example_write():
     lang = tarski.language('standard', [Theory.BOOLEAN, Theory.EQUALITY, Theory.ARITHMETIC, Theory.RANDOM])
-    the_task = Task(lang, 'academic_advising', 'instance_001')
+    the_task = Task(lang, 'academic_advising', 'academic_advising_001')
 
     the_task.requirements = [rddl.Requirements.REWARD_DET, rddl.Requirements.PRECONDITIONS]
 
@@ -513,7 +513,7 @@ def test_rddl_integration_with_boolean_patterns_academic_advising_example_write(
     false = lang.constant(0, lang.Boolean)
 
     # cpfs
-    the_task.add_cpfs(passed(c), ite((take_course(c) == 1) & ~(sumterm(c2, PREREQ(c2, c)) > 0),
+    the_task.add_cpfs(passed(c), ite((take_course(c) == 1) & ~(exists(c2, PREREQ(c2, c) == 1)),
                                      bernoulli(PRIOR_PROB_PASS_NO_PREREQ(c)),
                                      ite((take_course(c) == 1),
                                          bernoulli(PRIOR_PROB_PASS(c) +
@@ -525,12 +525,12 @@ def test_rddl_integration_with_boolean_patterns_academic_advising_example_write(
     the_task.add_cpfs(taken(c), (taken(c) == 1) | (take_course(c) == 1))
 
     # cost function
-    the_task.reward = ( sumterm(c, COURSE_COST() * (ite((take_course(c) == 1) & (taken(c) == 0), true, false)))
-                        + sumterm(c, COURSE_RETAKE_COST() * (ite((take_course(c) == 1) & (taken(c) == 1), true, false))
-                        + (PROGRAM_INCOMPLETE_PENALTY() * ite(~(forall(c, (PROGRAM_REQUIREMENT(c) == 1) > (passed(c) == 1))), true, false))))
+    the_task.reward = ( sumterm(c, COURSE_COST() * (ite((take_course(c) == 1) & ~(taken(c) == 1), true, false)))
+                        + sumterm(c, COURSE_RETAKE_COST() * (ite((take_course(c) == 1) & (taken(c) == 1), true, false)))
+                        + (PROGRAM_INCOMPLETE_PENALTY() * ite(~(forall(c, (PROGRAM_REQUIREMENT(c) == 1) > (passed(c) == 1))), true, false)))
 
     # constraints
-    the_task.add_constraint(forall(c, ((take_course(c) == 1) > (passed(c) == 0))), rddl.ConstraintType.ACTION)
+    the_task.add_constraint(forall(c, ((take_course(c) == 1) > ~(passed(c) == 1))), rddl.ConstraintType.ACTION)
     the_task.add_constraint(sumterm(c, take_course(c)) <= COURSES_PER_SEMESTER(), rddl.ConstraintType.ACTION)
 
     # fluent metadata
@@ -601,7 +601,7 @@ def test_rddl_integration_with_boolean_patterns_academic_advising_example_write(
     the_task.x0.set(PROGRAM_REQUIREMENT(c0202), 1)
     the_task.x0.set(PROGRAM_REQUIREMENT(c0101), 1)
     the_task.x0.set(PROGRAM_REQUIREMENT(c0002), 1)
-    the_task.x0.set(PROGRAM_REQUIREMENT(c0001), 1)
+    the_task.x0.set(PROGRAM_REQUIREMENT(c0001), 0)
 
     the_task.x0.set(passed(c0000), 0)
 

--- a/tests/io/test_rddl_writer.py
+++ b/tests/io/test_rddl_writer.py
@@ -383,7 +383,7 @@ def test_parametrized_model_with_random_vars_and_waypoints_boolean():
     uy = lang.function('uy', vehicle, lang.Real)
     t = lang.function('t', lang.Real)
 
-    wv = lang.predicate('visited', waypoint)
+    wv = lang.function('visited', waypoint, lang.Boolean)
 
     # objects
     v001 = lang.constant('v001', vehicle)
@@ -470,5 +470,143 @@ def test_parametrized_model_with_random_vars_and_waypoints_boolean():
     mr_reader = rddl.Reader(rddl_filename)
     assert mr_reader.rddl_model is not None
     assert mr_reader.rddl_model.domain.name == 'lqg_nav_2d_multi_unit_bool_waypoints'
+    mr_reader.translate_rddl_model()
+    assert mr_reader.language is not None
+
+
+def test_rddl_integration_with_boolean_patterns_academic_advising_example_write():
+    lang = tarski.language('standard', [Theory.BOOLEAN, Theory.EQUALITY, Theory.ARITHMETIC, Theory.RANDOM])
+    the_task = Task(lang, 'academic_advising', 'instance_001')
+
+    the_task.requirements = [rddl.Requirements.REWARD_DET, rddl.Requirements.PRECONDITIONS]
+
+    the_task.parameters.discount = 1.0
+    the_task.parameters.horizon = 20
+    the_task.parameters.max_nondef_actions = 1
+
+    #sorts
+    course = lang.sort('course')
+
+    # variables
+    c = lang.variable('c', course)
+    c2 = lang.variable('c2', course)
+
+    # non fluents
+    PREREQ = lang.function('PREREQ', course, course, lang.Boolean)
+    PRIOR_PROB_PASS_NO_PREREQ = lang.function('PRIOR_PROB_PASS_NO_PREREQ', course, lang.Real)
+    PRIOR_PROB_PASS = lang.function('PRIOR_PROB_PASS', course, lang.Real)
+    PROGRAM_REQUIREMENT = lang.function('PROGRAM_REQUIREMENT', course, lang.Boolean)
+    COURSE_COST = lang.function('COURSE_COST', lang.Real)
+    COURSE_RETAKE_COST = lang.function('COURSE_RETAKE_COST', lang.Real)
+    PROGRAM_INCOMPLETE_PENALTY = lang.function('PROGRAM_INCOMPLETE_PENALTY', lang.Real)
+    COURSES_PER_SEMESTER = lang.function('COURSES_PER_SEMESTER', lang.Real)
+
+    # state fluents
+    passed = lang.function('passed', course, lang.Boolean)
+    taken = lang.function('taken', course, lang.Boolean)
+
+    # action fluents
+    take_course = lang.function('take-course', course, lang.Boolean)
+
+    one = lang.constant(1, lang.Real)
+    # cpfs
+    the_task.add_cpfs(passed(c), ite((take_course(c) == 1) & ~(sum(c2, PREREQ(c2, c)) > 0),
+                                     bernoulli(PRIOR_PROB_PASS_NO_PREREQ(c)),
+                                     ite((take_course(c) == 1),
+                                         bernoulli(PRIOR_PROB_PASS(c) +
+                                         ((one - PRIOR_PROB_PASS(c))
+                                                   * (sumterm(c2, (PREREQ(c2, c) & passed(c2))))
+                                                   / (one + sumterm(c2, (PREREQ(c2, c)))))),
+                                         passed(c))))
+
+    the_task.add_cpfs(taken(c), (taken(c) == 1) | (take_course(c) == 1))
+
+    # cost function
+    the_task.reward = ( sumterm(c, COURSE_COST() * (ite((take_course(c) == 1) & (taken(c) == 0), one, zero)))
+                        + sumterm(c, COURSE_RETAKE_COST() * (ite((take_course(c) == 1) & (taken(c) == 1)))
+                        + (PROGRAM_INCOMPLETE_PENALTY() * ite(~(forall(c, (PROGRAM_REQUIREMENT(c) == 1) > (passed(c) == 1)), 1, 0)))))
+
+    # constraints
+    the_task.add_constraint(forall(c, ((take_course(c) == 1) > (passed(c) == 0)), rddl.ConstraintType.ACTION))
+    the_task.add_constraint(sumterm(c, take_course(c)) <= COURSES_PER_SEMESTER(), rddl.ConstraintType.ACTION)
+
+    # fluent metadata
+    the_task.declare_state_fluent(passed(c), 0)
+    the_task.declare_state_fluent(taken(c), 0)
+    the_task.declare_action_fluent(take_course(c), 0)
+    the_task.declare_non_fluent(PREREQ(c, c2), 0)
+    the_task.declare_non_fluent(PRIOR_PROB_PASS_NO_PREREQ(c), 0.8)
+    the_task.declare_non_fluent(PRIOR_PROB_PASS(c), 0.2)
+    the_task.declare_non_fluent(PROGRAM_REQUIREMENT(c), 0)
+    the_task.declare_non_fluent(COURSE_COST(), -1)
+    the_task.declare_non_fluent(COURSE_RETAKE_COST(), -2)
+    the_task.declare_non_fluent(PROGRAM_INCOMPLETE_PENALTY(), -5)
+    the_task.declare_non_fluent(COURSES_PER_SEMESTER(), 1)
+
+    #constants
+    c0000 = lang.constant('c0000', course)
+    c0001 = lang.constant('c0001', course)
+    c0002 = lang.constant('c0002', course)
+    c0003 = lang.constant('c0003', course)
+    c0004 = lang.constant('c0004', course)
+    c0100 = lang.constant('c0100', course)
+    c0101 = lang.constant('c0101', course)
+    c0102 = lang.constant('c0102', course)
+    c0103 = lang.constant('c0103', course)
+    c0200 = lang.constant('c0200', course)
+    c0201 = lang.constant('c0201', course)
+    c0202 = lang.constant('c0202', course)
+    c0300 = lang.constant('c0300', course)
+    c0301 = lang.constant('c0301', course)
+    c0302 = lang.constant('c0302', course)
+
+    the_task.x0.set(PRIOR_PROB_PASS_NO_PREREQ(c0000), 0.80)
+    the_task.x0.set(PRIOR_PROB_PASS_NO_PREREQ(c0001), 0.55)
+    the_task.x0.set(PRIOR_PROB_PASS_NO_PREREQ(c0002), 0.67)
+    the_task.x0.set(PRIOR_PROB_PASS_NO_PREREQ(c0003), 0.78)
+    the_task.x0.set(PRIOR_PROB_PASS_NO_PREREQ(c0004), 0.75)
+    the_task.x0.set(PRIOR_PROB_PASS(c0100), 0.22)
+    the_task.x0.set(PRIOR_PROB_PASS(c0101), 0.45)
+    the_task.x0.set(PRIOR_PROB_PASS(c0102), 0.41)
+    the_task.x0.set(PRIOR_PROB_PASS(c0103), 0.44)
+    the_task.x0.set(PRIOR_PROB_PASS(c0200), 0.14)
+    the_task.x0.set(PRIOR_PROB_PASS(c0201), 0.07)
+    the_task.x0.set(PRIOR_PROB_PASS(c0202), 0.24)
+    the_task.x0.set(PRIOR_PROB_PASS(c0300), 0.23)
+    the_task.x0.set(PRIOR_PROB_PASS(c0301), 0.08)
+    the_task.x0.set(PRIOR_PROB_PASS(c0302), 0.16)
+
+
+    the_task.x0.set(PREREQ(c0003, c0100), 1)
+    the_task.x0.set(PREREQ(c0000, c0100), 1)
+    the_task.x0.set(PREREQ(c0004, c0100), 1)
+    the_task.x0.set(PREREQ(c0001, c0101), 1)
+    the_task.x0.set(PREREQ(c0002, c0101), 1)
+    the_task.x0.set(PREREQ(c0000, c0102), 1)
+    the_task.x0.set(PREREQ(c0004, c0102), 1)
+    the_task.x0.set(PREREQ(c0001, c0103), 1)
+    the_task.x0.set(PREREQ(c0001, c0200), 1)
+    the_task.x0.set(PREREQ(c0101, c0200), 1)
+    the_task.x0.set(PREREQ(c0103, c0201), 1)
+    the_task.x0.set(PREREQ(c0002, c0202), 1)
+    the_task.x0.set(PREREQ(c0200, c0300), 1)
+    the_task.x0.set(PREREQ(c0201, c0301), 1)
+    the_task.x0.set(PREREQ(c0201, c0301), 1)
+    the_task.x0.set(PREREQ(c0200, c0302), 1)
+
+    the_task.x0.set(PROGRAM_REQUIREMENT(c0300), 1)
+    the_task.x0.set(PROGRAM_REQUIREMENT(c0202), 1)
+    the_task.x0.set(PROGRAM_REQUIREMENT(c0101), 1)
+    the_task.x0.set(PROGRAM_REQUIREMENT(c0002), 1)
+    the_task.x0.set(PROGRAM_REQUIREMENT(c0001), 1)
+
+    the_task.x0.set(passed(c0000), 0)
+
+    the_writer = rddl.Writer(the_task)
+    rddl_filename = os.path.join(tempfile.gettempdir(), 'academic_advising_001.rddl')
+    the_writer.write_model(rddl_filename)
+    mr_reader = rddl.Reader(rddl_filename)
+    assert mr_reader.rddl_model is not None
+    assert mr_reader.rddl_model.domain.name == 'academic_advising'
     mr_reader.translate_rddl_model()
     assert mr_reader.language is not None


### PR DESCRIPTION
Note that this PR is submitted as a draft, since the true PR should probably be opened against a separate feature branch, rather than `devel`.

Boolean interop for RDDL requires the ability to move from `Term -> Formula` and from `Formula -> Term` within the AST built in `Tarski` as discussed in #91. In general, we need the ability to construct nested formulae which include *both* logical operations on expressions with atoms based on the numerically-derived `Boolean` sort, and direct mathematical operations on these items.

To accomplish this in practice, two patterns can be used.

### 1) `Term -> Formula`: ###
Given a `Term` with sort `Boolean`, we can use the typical equality predicate and a constant `True/1` value to wrap to a `Formula` (for a language which has both the `Boolean` and `Equality` theories attached)
````
a = lang.function('a', lang.Boolean)
b = lang.function('b', lang.Boolean)
bool_t = lang.constant(1, lang.Boolean)
logical_formula = (a == bool_t) | (b == bool_t)
````

### 2) `Formula -> Term`: ###
Given a `Formula`, we can wrap out to a `Term` with sort `Boolean` using the `IfThenElse` term, and corresponding boolean constants.

````
a = lang.function('a', lang.Boolean)
b = lang.function('b', lang.Boolean)
bool_t = lang.constant(1, lang.Boolean)
logical_formula = (a == bool_t) | (b == bool_t)
math_included = ite(logical_formula, bool_t, lang.constant(0, lang.Boolean)) + 1 
````

With these two patterns, we can arbitrarily move back and forth between `Formula` and `Term` objects depending on the operations needed when building the AST in `Tarski`. Additionally, because these patterns are easily identifiable with simple pattern matching, when performing write-side IO for an RDDL domain which includes these wrappers within the `Tarski` representation, we can remove the wrappers accordingly, and generate legal RDDL which does not include the additional representational overhead involved with the wrapper patterns discussed above.

The `Tarski` modeling approach for RDDL using these patterns involves representing Boolean RDDL values as `Boolean` (sort) codomain functions, with equality-based atoms as the basic logical type (e.g. `(a == lang.constant(1, lang.Boolean)`). This is in contrast to the approach explored in the `rddl-support` branch (#96), which assumed the use of `Predicate` for representation of Boolean RDDL values. One additional advantage of this change is that while the closed-world assumption prohibits the declaration of `false`-valued `non-fluent`s and initial-state `state-fluent`s (necessary in RDDL, since Boolean valued fluents can be declared with default values of `true`) in an implementation based on `Predicate` representations for these fluents (as in #96), the use of `Boolean` codomain functions in this alternate approach trivially avoids this issue.

## Included changes/additions: ##
1. Incorporating a `Boolean` sort descended from `Natural` when the Boolean theory is attached to a `FirstOrderLanguage`
2. Addition of `Bernoulli` as a builtin for the `Random` theory
3. Implementation additions in RDDL write IO in order to "unwrap" the two major patterns used to translate back and forth between `Formula` and `Term` items when using the `Boolean` sort as described.
4. Minor changes to write `true` and `false` literals rather than `0/1` when writing RDDL from our representation (needed as far as I know for appropriate behavior with both the `PROST` and `rddlsim` RDDL parsers)
4. Test additions & modifications to test RDDL write-side IO support, along with tests for the `Boolean` theory changes

## Omissions/Necessary future discussion ##
1. Current tests are focused on write-side RDDL IO. Neither the read-side tests, nor the read-side RDDL IO code has been modified to automatically wrap back and forth using the two patterns above.
2. From a user perspective (when using `Tarski` as a tool to directly construct the AST and domain/instance models for RDDL-specified problems) requiring the explicit use of these wrappers puts significant onus on the user to understand the distinction between `Formula` and `Term` within `Tarski` in order to appropriately use these wrappers and correctly construct their domain/instance. While this is potentially workable, it would be preferable from the user's perspective to have some level of "automatic" injection of wrappers in instances where there is a mismatch between input to an operator and the expected object type (e.g. when dispatching a `lor` called from a `Formula` where the argument is a `Term` with sort `Boolean`). This would involve building recovery logic with knowledge of the `Boolean` sort into `Tarski`'s operator dispatching implementation, which may or may not be acceptable from a design standpoint. This may be a worthwhile point of discussion!