### PR TITLE
Switch to clingo pypi package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,9 @@ def main():
             # Antlr pinned to a specific version to avoid messages "ANTLR runtime and generated code versions disagree"
             # messages. If we want to bump this up, we'll need to regenerate the grammar files with the new version.
             'antlr4-python3-runtime==4.7.2',
+
+            # Clingo (gringo) bindings to the clingo solver
+            'clingo>=5.5.1',
         ],
 
         extras_require={

--- a/src/tarski/reachability/gringo.py
+++ b/src/tarski/reachability/gringo.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+import sys
+from clingo.application import Application, clingo_main
+
+"""
+A wrapper to emulate the default clingo app behavior
+"""
+class WrapperClingo(Application):
+    def __init__(self, name):
+        self.app_name = name
+
+    def main(self, ctl, files):
+        """
+        The default implementation from clingo documentation
+        Note- main(...) must be implemented
+        """
+        for f in files:
+            ctl.load(f)
+        if not files:
+            ctl.load("-")
+        ctl.ground([("base", [])])
+        ctl.solve()
+
+"""
+run the clingo application in the default gringo mode
+"""
+clingo_main(WrapperClingo("gringo"), ["--mode", "gringo"]+sys.argv[1:])


### PR DESCRIPTION
Alters the clingo_wrapper,  removing the requirement to manually install clingo(gringo) binary.