### PR TITLE
 Corrected the name of the WrapperClingo class member

### DIFF
--- a/src/tarski/reachability/gringo.py
+++ b/src/tarski/reachability/gringo.py
@@ -7,7 +7,7 @@ A wrapper to emulate the default clingo app behavior
 """
 class WrapperClingo(Application):
     def __init__(self, name):
-        self.app_name = name
+        self.program_name = name
 
     def main(self, ctl, files):
         """


### PR DESCRIPTION
  Corrected the name of the `WrapperClingo` class member to match that of the parent class `Application`. This was a typo.